### PR TITLE
Fix HASS Error `Error while parsing localized (ru) string component.pik_intercom.options.error.iot_update_interval_too_low`

### DIFF
--- a/custom_components/pik_intercom/translations/ru.json
+++ b/custom_components/pik_intercom/translations/ru.json
@@ -28,7 +28,7 @@
       "auth_update_interval_too_low": "Интервал слишком мал (минимум: {min_auth_update_interval}с)",
       "intercoms_update_interval_too_low": "Интервал слишком мал (минимум: {min_intercoms_update_interval}с)",
       "last_call_session_update_interval_too_low": "Интервал слишком мал (минимум: {min_last_call_session_update_interval}с)",
-      "iot_update_interval_too_low": "Интервал слишком мал (минимум: {min_@{self.domain}update_interval}с)",
+      "iot_update_interval_too_low": "Интервал слишком мал (минимум: {min_iot_update_interval}с)",
       "device_id_invalid_characters": "Идентификатор устройства может содержать только буквенно-цифровые латинские символы (a-z, A-Z, 0-9)",
       "device_id_too_short": "Минимальная длина идентификатора — {min_device_id_length} символов"
     },


### PR DESCRIPTION
Fix HASS Error `Error while parsing localized (ru) string component.pik_intercom.options.error.iot_update_interval_too_low`

---

Full error is:

```
Logger: homeassistant.helpers.translation
Source: helpers/translation.py:276
First occurred: 01:54:20 (1 occurrences)
Last logged: 01:54:20

Error while parsing localized (ru) string component.pik_intercom.options.error.iot_update_interval_too_low
```